### PR TITLE
Input display improvements and fixes

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -158,6 +158,10 @@ body {
 .border-underline-blue {
   box-shadow: 0 2px 0 0 rgb(59, 130, 246);
 }
+.scroll_overflow_shadow {
+  mask-image: linear-gradient(black 95%, transparent 100%);
+  -webkit-mask-image: linear-gradient(black 95%, transparent 100%);
+}
 
 .editMarkerOverlay {
   z-index: 1000; /* Adjust the z-index as needed */

--- a/frontend/components/component/askingView.tsx
+++ b/frontend/components/component/askingView.tsx
@@ -18,7 +18,7 @@ export default function AskingView({ onEditSave, editedText, setGeoJsonPath, set
   const [loading, setLoading] = useState(true);
   const [inputText, setInputText] = useState('');
   const [markers, setMarkers] = useState<{ latitude: number; longitude: number; type: string; }[]>([]);
-  const [centerCoordinates, setCenterCoordinates] = useState<[number, number] | null>(null);
+  
 
   const isInitialRender = useRef(true);
   const prevEditedTextRef = useRef<string | undefined>('');
@@ -142,7 +142,6 @@ export default function AskingView({ onEditSave, editedText, setGeoJsonPath, set
           <div style={{ height: 'calc(100vh - 57px)' }}>
             <MapComponent
               markers={markers}
-              centerCoordinates={centerCoordinates}
               selectedMarkerIndex={selectedMarkerIndex}
               setSelectedMarkerIndex={setSelectedMarkerIndex}
               geojsonData={jsonData?.selected_countries_geojson_path}

--- a/frontend/components/component/askingView.tsx
+++ b/frontend/components/component/askingView.tsx
@@ -1,6 +1,6 @@
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { Button, } from "@/components/ui/button";
-import { Input } from "@/components/ui/input"
+import { Input } from "@/components/ui/input";
 import { useState, useEffect, useRef } from "react";
 import { ScrollArea } from "../ui/scroll-area";
 import MapComponent from "./mapComponent";
@@ -8,6 +8,7 @@ import JsonRenderer from "../functions/JsonRenderer";
 import ReactDOMServer from 'react-dom/server';
 import { handleSaveChat, handleSendChat } from '../functions/ApiUtils';
 import { Bbl } from '../ui/bbl';
+import { InputDisplay } from './inputDisplay';
 
 export default function AskingView({ onEditSave, editedText, setGeoJsonPath, setMarkersToolbar }: { onEditSave: (text: string) => void, editedText: string, setGeoJsonPath: (path: string) => void, setMarkersToolbar: (markers: { latitude: number; longitude: number; type: string; }[]) => void }) {
   const [selectedMarkerIndex, setSelectedMarkerIndex] = useState<number | null>(null);
@@ -45,10 +46,10 @@ export default function AskingView({ onEditSave, editedText, setGeoJsonPath, set
 
   // Save the text to the backend
   useEffect(() => {
-    if (!isInitialRender.current) { return; } 
+    if (!isInitialRender.current) { return; }
     // Set state so call is made only once if run in local dev outside docker
     isInitialRender.current = false;
-  
+
     handleSaveChat(editedText, setEditingText, setCenterCoordinates, setLoading, setJsonData, setMarkers, setLocalEditedText, prevEditedTextRef);
     console.log("Text sendt to backend!");
   }, [editedText]);
@@ -76,9 +77,9 @@ export default function AskingView({ onEditSave, editedText, setGeoJsonPath, set
   };
 
   return (
-    <div className="bg-white overflow-y-auto dark:bg-gray-800">
+    <div className="bg-white dark:bg-gray-800 dark:text-white overflow-y-auto">
       <div className="flex">
-        <aside className="w-1/3 p-4 space-y-4 border-r flex flex-col" style={{ flex: '0 0 auto', height: 'calc(100vh - 57px)' }}>
+         {/* <aside className="w-1/3 p-4 space-y-4 border-r flex flex-col" style={{ flex: '0 0 auto', height: 'calc(100vh - 57px)' }}>
           <div className="flex items-center justify-between w-full dark:text-white">
             {editingText ? (
               <Input
@@ -101,7 +102,7 @@ export default function AskingView({ onEditSave, editedText, setGeoJsonPath, set
           )}
           {!editingText && (
             <div className="flex justify-center space-x-2 mt-auto self-center0">
-              <Button onClick={handleEditClick} variant="secondary" className="flex items-center justify-center space-x-2" > {/*variant="secondary">Needs darkmode*/}
+              <Button onClick={handleEditClick} variant="secondary" className="flex items-center justify-center space-x-2" >
                 <span>Edit & add text</span>
               </Button>
             </div>
@@ -129,7 +130,14 @@ export default function AskingView({ onEditSave, editedText, setGeoJsonPath, set
               Send
             </Button>
           </div>
-        </aside>
+        </aside> */}
+
+        <InputDisplay
+          displayState={1} // For manual text-input
+          input={localEditedText}
+          jsonData={jsonData}
+          markers={markers}
+        />
         <main className="flex-auto relative w-2/3">
           <div style={{ height: 'calc(100vh - 57px)' }}>
             <MapComponent

--- a/frontend/components/component/askingView.tsx
+++ b/frontend/components/component/askingView.tsx
@@ -10,18 +10,28 @@ import { handleSaveChat, handleSendChat } from '../functions/ApiUtils';
 import { Bbl } from '../ui/bbl';
 import { InputDisplay } from './inputDisplay';
 
-export default function AskingView({ onEditSave, editedText, setGeoJsonPath, setMarkersToolbar }: { onEditSave: (text: string) => void, editedText: string, setGeoJsonPath: (path: string) => void, setMarkersToolbar: (markers: { latitude: number; longitude: number; type: string; }[]) => void }) {
-  const [selectedMarkerIndex, setSelectedMarkerIndex] = useState<number | null>(null);
-  const [editingText, setEditingText] = useState(false);
-  const [localEditedText, setLocalEditedText] = useState('');
-  const [jsonData, setJsonData] = useState<any>(null);
+export default function AskingView({
+  inputText,
+  onSaveEditText,
+  setGeoJsonPath,
+  setMarkersToolbar
+}: {
+  inputText: string,
+  onSaveEditText: (text: string) => void,
+  setGeoJsonPath: React.Dispatch<React.SetStateAction<string | null>>,
+  setMarkersToolbar: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string; }[]>>
+}) {
   const [loading, setLoading] = useState(true);
-  const [inputText, setInputText] = useState('');
+  //const [newText, setNewText] = useState('');
+  //const [editingText, setEditingText] = useState(false);
+  //const [localEditedText, setLocalEditedText] = useState('');
+
+  const [jsonData, setJsonData] = useState<any>(null);
+  const [selectedMarkerIndex, setSelectedMarkerIndex] = useState<number | null>(null);
   const [markers, setMarkers] = useState<{ latitude: number; longitude: number; type: string; }[]>([]);
-  
 
   const isInitialRender = useRef(true);
-  const prevEditedTextRef = useRef<string | undefined>('');
+  //const prevEditedTextRef = useRef<string | undefined>('');
 
 
   // Ask user if he wants to reload the page
@@ -44,32 +54,27 @@ export default function AskingView({ onEditSave, editedText, setGeoJsonPath, set
     }
   }, [jsonData?.selected_countries_geojson_path]);
 
-  // Save the text to the backend
+  // Send the request to the backend
   useEffect(() => {
+    // If this is commented out, the effect runs more than once
     if (!isInitialRender.current) { return; }
     // Set state so call is made only once if run in local dev outside docker
     isInitialRender.current = false;
 
-    handleSaveChat(editedText, setEditingText, setCenterCoordinates, setLoading, setJsonData, setMarkers, setLocalEditedText, prevEditedTextRef);
+    //handleSaveChat(inputText, setEditingText, setLoading, setJsonData, setMarkers, setLocalEditedText, prevEditedTextRef);
+    //handleSaveChat(inputText, setLoading, setJsonData, setMarkers);
+    //sendChatRequest(inputText);
     console.log("Text sendt to backend!");
-  }, [editedText]);
+    setLoading(false);
+  }, [inputText]);
 
-  // Handle the case where the user clicks the "Edit & add text" button
-  const handleEditClick = () => {
-    setEditingText(true);
-  };
 
-  // Save the text to the backend
-  const handleSaveTextWrapper = () => {
-    handleSaveChat(localEditedText, setEditingText, setCenterCoordinates, setLoading, setJsonData, setMarkers, setLocalEditedText, prevEditedTextRef);
-  };
-
-  // Send the text to the backend
-  const handleSendTextWrapper = () => {
-    if (typeof inputText === 'string' && inputText.trim() !== "") {
-      handleSendChat(inputText, setJsonData, setCenterCoordinates, setMarkers, setInputText, setLoading);
+  // Handler for sending additional chat requests to the backend
+  const handleSendTextWrapper = (request: string) => {
+    if (request.trim() !== "") {
+      handleSendChat(request, setJsonData, setMarkers, setLoading);
       // Set the inputText to an empty string after sending the request
-      setInputText("");
+      //setNewText("");
     } else {
       // Handle case where inputText is not a string or is empty
       console.log('Input text is not a string or is empty. Not sending the request.');
@@ -134,9 +139,12 @@ export default function AskingView({ onEditSave, editedText, setGeoJsonPath, set
 
         <InputDisplay
           displayState={1} // For manual text-input
-          input={localEditedText}
+          loading={loading}
+          input={inputText}
           jsonData={jsonData}
           markers={markers}
+          onSaveEditText={onSaveEditText}
+          onSendRequest={handleSendTextWrapper}
         />
         <main className="flex-auto relative w-2/3">
           <div style={{ height: 'calc(100vh - 57px)' }}>

--- a/frontend/components/component/askingView.tsx
+++ b/frontend/components/component/askingView.tsx
@@ -1,13 +1,7 @@
 import 'mapbox-gl/dist/mapbox-gl.css';
-import { Button, } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useState, useEffect, useRef } from "react";
-import { ScrollArea } from "../ui/scroll-area";
 import MapComponent from "./mapComponent";
-import JsonRenderer from "../functions/JsonRenderer";
-import ReactDOMServer from 'react-dom/server';
-import { handleSaveChat, handleSendChat } from '../functions/ApiUtils';
-import { Bbl } from '../ui/bbl';
+import { handleSendChatRequest, handleAddRequestToChat } from '../functions/ApiUtils';
 import { InputDisplay } from './inputDisplay';
 
 export default function AskingView({
@@ -61,89 +55,38 @@ export default function AskingView({
     // Set state so call is made only once if run in local dev outside docker
     isInitialRender.current = false;
 
-    //handleSaveChat(inputText, setEditingText, setLoading, setJsonData, setMarkers, setLocalEditedText, prevEditedTextRef);
-    //handleSaveChat(inputText, setLoading, setJsonData, setMarkers);
-    //sendChatRequest(inputText);
-    console.log("Text sendt to backend!");
-    setLoading(false);
+    handleSendChatRequest(inputText, setJsonData, setMarkers, setLoading);
   }, [inputText]);
 
+  const handleSaveEditText = (editText: string) => {
+    onSaveEditText(editText); // Pass value upwards
+    
+    // Ensure request is resendt
+    handleSendChatRequest(editText, setJsonData, setMarkers, setLoading);
+  }
 
   // Handler for sending additional chat requests to the backend
   const handleSendTextWrapper = (request: string) => {
-    if (request.trim() !== "") {
-      handleSendChat(request, setJsonData, setMarkers, setLoading);
-      // Set the inputText to an empty string after sending the request
-      //setNewText("");
-    } else {
+    if (request.trim() === "") {
       // Handle case where inputText is not a string or is empty
       console.log('Input text is not a string or is empty. Not sending the request.');
+      return;
     }
+
+    // If all is good, send call to handler
+    handleAddRequestToChat(request, setJsonData, setMarkers, setLoading);
   };
 
   return (
     <div className="bg-white dark:bg-gray-800 dark:text-white overflow-y-auto">
       <div className="flex">
-         {/* <aside className="w-1/3 p-4 space-y-4 border-r flex flex-col" style={{ flex: '0 0 auto', height: 'calc(100vh - 57px)' }}>
-          <div className="flex items-center justify-between w-full dark:text-white">
-            {editingText ? (
-              <Input
-                name="EditField"
-                type="text"
-                value={localEditedText}
-                onChange={(e) => setLocalEditedText(e.target.value)}
-                className="p-2 text-lg font-semibold"
-              />
-            ) : (
-              <h1 className="p-2 rounded text-2xl font-semibold">{localEditedText}</h1>
-            )}
-          </div>
-          {editingText && (
-            <div className="flex items-center justify-center space-x-2 mt-auto">
-              <Button onClick={handleSaveTextWrapper} variant="secondary">
-                Save
-              </Button>
-            </div>
-          )}
-          {!editingText && (
-            <div className="flex justify-center space-x-2 mt-auto self-center0">
-              <Button onClick={handleEditClick} variant="secondary" className="flex items-center justify-center space-x-2" >
-                <span>Edit & add text</span>
-              </Button>
-            </div>
-          )}
-          <ScrollArea>
-            <div className="dark:text-white">
-              {loading ? (
-                <Bbl />
-              ) : (
-                <div>
-                  <JsonRenderer jsonData={jsonData} />
-                </div>
-              )}
-            </div>
-          </ScrollArea>
-          <div className="flex justify-center space-x-2 mt-auto">
-            <Input
-              name="ChatInput"
-              placeholder="Type your message here..."
-              type="text"
-              value={inputText}
-              onChange={(e) => setInputText(e.target.value)}
-            />
-            <Button className="dark:bg-gray-300 dark:hover:bg-gray-500" onClick={handleSendTextWrapper} disabled={inputText?.trim() === ""}>
-              Send
-            </Button>
-          </div>
-        </aside> */}
-
         <InputDisplay
-          displayState={1} // For manual text-input
+          displayState={1} // 1 for chat-input
           loading={loading}
           input={inputText}
           jsonData={jsonData}
           markers={markers}
-          onSaveEditText={onSaveEditText}
+          onSaveEditText={handleSaveEditText}
           onSendRequest={handleSendTextWrapper}
         />
         <main className="flex-auto relative w-2/3">

--- a/frontend/components/component/edit-marker.tsx
+++ b/frontend/components/component/edit-marker.tsx
@@ -6,13 +6,13 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { CloseIcon, PaintbrushIcon } from "../ui/icons";
 import { Textarea } from "@/components/ui/textarea"
-import React, {useState} from "react";
+import React, { useState } from "react";
 
-export function EditMarker({ onClose, onTitleChange, title }: { 
+export function EditMarker({ onClose, onTitleChange, title }: {
   onClose: () => void;
   onTitleChange: (newTitle: string) => void;
   title: string;
- }) {
+}) {
 
   const [inputTitle, setInputTitle] = useState(title);
 
@@ -23,18 +23,31 @@ export function EditMarker({ onClose, onTitleChange, title }: {
 
   return (
     <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center p-4">
-      <div className="bg-white rounded-lg max-w-2xl w-full p-6 space-y-4 relative">
+      <div className="bg-white dark:bg-gray-800 rounded-lg max-w-2xl w-full p-6 space-y-4 relative">
         <button className="absolute top-4 right-4">
-          <CloseIcon className="h-6 w-6" onClick={onClose}/>
+          <CloseIcon className="h-6 w-6" onClick={onClose} />
         </button>
         <h2 className="text-xl font-semibold">Edit location</h2>
         <div className="flex flex-col space-y-3">
           <div className="flex items-center space-x-3">
-            <Input placeholder="Location name / Address / Lat. - Long." value={inputTitle} onChange={(e) => setInputTitle(e.target.value)}/>
+            <Input placeholder="Location name / Address / Lat. - Long." value={inputTitle} onChange={(e) => setInputTitle(e.target.value)} />
           </div>
           <Textarea placeholder="Add details and information about this location..." />
         </div>
-        <Button className="w-full" onClick={handleUpdate}>Update</Button>
+        <div className="flex gap-5">
+          <Button
+            className="w-1/2"
+            variant={"secondary"}
+            onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            className="w-1/2"
+            variant={"blue"}
+            onClick={handleUpdate}>
+            Update
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/frontend/components/component/inputDisplay.tsx
+++ b/frontend/components/component/inputDisplay.tsx
@@ -37,8 +37,7 @@ const InputDisplay = (props: InputDisplayProps) => {
   const editInputRef = useRef<HTMLTextAreaElement>(null);
 
   //AutosizeTextArea
-  // autosizeTextArea(newInputRef.current, newText);
-  autosizeTextArea(editInputRef.current, editText, props.loading);
+  autosizeTextArea(editInputRef.current, editText);
 
   useEffect(() => {
     setNumberOfLocations(props.markers.length);
@@ -58,6 +57,11 @@ const InputDisplay = (props: InputDisplayProps) => {
 
   // Handle the save event and pass value up to parent
   const handleSaveEdit = () => {
+    if (editText.trim() == props.input) {
+      console.log("New text was same as old one. No need to repeat request.");
+      return;
+    }
+
     props.onSaveEditText(editText.trim());
     setEditTextState(false);
   };
@@ -86,56 +90,53 @@ const InputDisplay = (props: InputDisplayProps) => {
           <Pencil className="inline w-5 h-5 mr-2" />Edit text
         </Button>
       </div>
-          {props.loading ? (
-            <Bbl />
-          ) : (
+      {props.loading ? (
+        <Bbl />
+      ) : (
         <div className="dark:text-white overflow-y-auto scroll_overflow_shadow">
-            <div className="whitespace-pre-wrap">
-              {(props.displayState === 1 || props.displayState === 2) &&
-                // Textarea displayed for editing text or main chat input
-                // Remains invisible and read-only when not in use, and opens when editing is enabled
-                // Can not be unloaded, as the size updates upon next statechange, resulting in a squished textarea on first load
-                <>
-                  <div
-                    className="sticky top-0 py-3 px-3 bg-white dark:bg-gray-800 border-b dark:border-b-gray-600"
-                    style={{ display: editTextState ? "" : "none" }} // This hides the border and padding from the page when not in use
-                  >
-                    <Textarea
-                      name="EditText"
-                      value={editText}
-                      style={{ display: editTextState ? "" : "none" }}
-                      hiddenState={editTextState ? 0 : 1}
-                      onChange={(e) => setEditText(e.target.value)}
-                      ref={editInputRef}
-                      readOnly={!editTextState}
-                    />
+          {(props.displayState === 1 || props.displayState === 2) &&
+            // This setup makes Textarea invisible and read-only when not in use, and displays it when editing is enabled
+            // For autosizing to work, Textarea can not be unloaded, as the size updates upon next statechange, resulting in a squished textarea on first load
+            // By making Textarea invisible, positioned relative, and with 0 height, it maintains the same dimentiones when hidden. This ensures that Textarea displays correctly when editing is enabled
+            <>
+              <div className={editTextState
+                ? "sticky top-0 py-3 px-3 bg-white dark:bg-gray-800 border-b dark:border-b-gray-600"
+                : "relative h-0 px-3 opacity-0 pointer-events-none"
+              }>
+                <Textarea
+                  name="EditText"
+                  value={editText}
+                  className='resize-none'
+                  onChange={(e) => setEditText(e.target.value)}
+                  ref={editInputRef}
+                  readOnly={!editTextState}
+                />
 
-                    {editTextState &&
-                      <div className="flex pt-2 space-x-2">
-                        <Button onClick={handleCancelEdit} variant="secondary">
-                          Cancel
-                        </Button>
-                        <Button onClick={handleSaveEdit} variant="blue" disabled={editText.trim() === ""}>
-                          Save & resend
-                        </Button>
-                      </div>
-                    }
+                {editTextState &&
+                  <div className="flex pt-2 space-x-2">
+                    <Button onClick={handleCancelEdit} variant="secondary">
+                      Cancel
+                    </Button>
+                    <Button onClick={handleSaveEdit} variant="blue" disabled={editText.trim() === ""}>
+                      Save & resend
+                    </Button>
                   </div>
+                }
+              </div>
 
 
-                  <div className="mb-10 p-3">
-                    {props.displayState === 1 &&
-                      // Display chat always, as the user can only edit initial input
-                      <JsonRenderer jsonData={props.jsonData} />
-                    }
-                    {props.displayState === 2 && !editTextState &&
-                      // Display text when not editing, because the textarea displays the same.
-                      <div>{editText}</div>
-                    }
-                  </div>
-                </>
-              }
-            </div>
+              <div className="mb-10 p-3 whitespace-pre-wrap">
+                {props.displayState === 1 &&
+                  // Display chat always, as the user can only edit initial input
+                  <JsonRenderer jsonData={props.jsonData} />
+                }
+                {props.displayState === 2 && !editTextState &&
+                  // Display text when not editing, because the textarea displays the same.
+                  <div>{editText}</div>
+                }
+              </div>
+            </>
+          }
         </div>
       )}
 

--- a/frontend/components/component/inputDisplay.tsx
+++ b/frontend/components/component/inputDisplay.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Button, } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ScrollArea } from "../ui/scroll-area";
 import JsonRenderer from "../functions/JsonRenderer";
 import { Bbl } from '../ui/bbl';
 import { Pencil } from '../ui/icons';
@@ -73,7 +72,7 @@ const InputDisplay = (props: InputDisplayProps) => {
 
 
   return (
-    <aside className="w-1/3 border-r flex flex-col">
+    <aside className="w-1/3 flex flex-col" style={{ height: 'calc(100vh - 57px)' }}>
       <div className="p-2 px-4 flex items-center justify-between border-b dark:border-b-gray-600 dark:bg-slate-900">
         <div className="items-center">
           {numberOfLocations} Locations
@@ -87,18 +86,21 @@ const InputDisplay = (props: InputDisplayProps) => {
           <Pencil className="inline w-5 h-5 mr-2" />Edit text
         </Button>
       </div>
-      <div className="flex flex-col h-full">
-        <ScrollArea>
-          <div className="px-3 py-5 dark:text-white">
-            {props.loading ? (
-              <Bbl />
-            ) : (
-              <div className="whitespace-pre-wrap">
-                {(props.displayState === 1 || props.displayState === 2) &&
-                  // Textarea displayed for editing text or main chat input
-                  // Remains invisible and read-only when not in use, and opens when editing is enabled
-                  // Can not be unloaded, as the size updates upon next statechange, resulting in a squished textarea on first load
-                  <>
+      <div className="overflow-y-auto scroll_overflow_shadow" style={{ boxShadow: 'rgb(31, 41, 55) 0px -30px 15px -20px inset' }}>
+        <div className=" dark:text-white">
+          {props.loading ? (
+            <Bbl />
+          ) : (
+            <div className="whitespace-pre-wrap">
+              {(props.displayState === 1 || props.displayState === 2) &&
+                // Textarea displayed for editing text or main chat input
+                // Remains invisible and read-only when not in use, and opens when editing is enabled
+                // Can not be unloaded, as the size updates upon next statechange, resulting in a squished textarea on first load
+                <>
+                  <div
+                    className="sticky top-0 py-3 px-3 bg-white dark:bg-gray-800 border-b dark:border-b-gray-600"
+                    style={{ display: editTextState ? "" : "none" }} // This hides the border and padding from the page when not in use
+                  >
                     <Textarea
                       name="EditText"
                       value={editText}
@@ -110,16 +112,19 @@ const InputDisplay = (props: InputDisplayProps) => {
                     />
 
                     {editTextState &&
-                      <div className="flex pt-2 mb-4 space-x-2">
+                      <div className="flex pt-2 space-x-2">
                         <Button onClick={handleCancelEdit} variant="secondary">
                           Cancel
                         </Button>
-                        <Button onClick={handleSaveEdit} variant="blue">
+                        <Button onClick={handleSaveEdit} variant="blue" disabled={editText.trim() === ""}>
                           Save & resend
                         </Button>
                       </div>
                     }
+                  </div>
 
+
+                  <div className="mb-10 p-3">
                     {props.displayState === 1 &&
                       // Display chat always, as the user can only edit initial input
                       <JsonRenderer jsonData={props.jsonData} />
@@ -128,28 +133,29 @@ const InputDisplay = (props: InputDisplayProps) => {
                       // Display text when not editing, because the textarea displays the same.
                       <div>{editText}</div>
                     }
-                  </>
-                }
-              </div>
-            )}
-          </div>
-        </ScrollArea>
-        {props.displayState === 1 &&
-          // Displays ChatInput when displaying chat
-          <div className="p-3 flex justify-center mt-auto space-x-2">
-            <Input
-              name="ChatInput"
-              placeholder="Type your message here..."
-              type="text"
-              value={newText}
-              onChange={(e) => setNewText(e.target.value)}
-            />
-            <Button variant="secondary" onClick={handleAddToChat} disabled={newText?.trim() === ""}>
-              Send
-            </Button>
-          </div>
-        }
+                  </div>
+                </>
+              }
+            </div>
+          )}
+        </div>
+
       </div>
+      {props.displayState === 1 &&
+        // Displays ChatInput when displaying chat
+        <div className="p-3 flex justify-center mt-auto space-x-2">
+          <Input
+            name="ChatInput"
+            placeholder="Type your message here..."
+            type="text"
+            value={newText}
+            onChange={(e) => setNewText(e.target.value)}
+          />
+          <Button variant="secondary" onClick={handleAddToChat} disabled={newText?.trim() === ""}>
+            Send
+          </Button>
+        </div>
+      }
     </aside>
   );
 }

--- a/frontend/components/component/inputDisplay.tsx
+++ b/frontend/components/component/inputDisplay.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "../ui/scroll-area";
+import JsonRenderer from "../functions/JsonRenderer";
+import { Bbl } from '../ui/bbl';
+import { Pencil } from '../ui/icons';
+import { Textarea } from '../ui/textarea';
+import autosizeTextArea from '../functions/AutosizeTextArea';
+
+
+/**
+ * 
+ * @param displayState Display for Chat, text or CSV
+ * @param input Input text
+ * @param JsonData Input jsonData
+ * @param markers List of markers to display related info
+ * @returns 
+ */
+const InputDisplay = (props: {
+  displayState: number,
+  input: any,
+  jsonData?: any,
+  markers: { latitude: number; longitude: number; type: string }[];
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [numberOfLocations, setNumberOfLocations] = useState(0);
+  const [displayText, setDisplayText] = useState(props.input);
+  const [editTextState, setEditTextState] = useState(false);
+  const [editText, setEditText] = useState(props.input);
+  const [inputNewText, setInputNewText] = useState('');
+  const [jsonData, setJsonData] = useState(props.jsonData);
+
+  //const newInputRef = useRef<HTMLTextAreaElement>(null);
+  const editInputRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleChange = (e: any) => {
+    setEditText(e.target.value);
+
+  };
+
+  //AutosizeTextArea
+  // autosizeTextArea(newInputRef.current, inputNewText);
+  autosizeTextArea(editInputRef.current, editText);
+
+
+  useEffect(() => {
+    setNumberOfLocations(props.markers.length);
+  }, [props.markers]);
+
+  useEffect(() => {
+    console.log('jsonData got changed: ', props.jsonData);
+
+  }, [props.jsonData])
+
+  // Handle the case where the user clicks the "Edit & add text" button
+  const handleEditClick = () => {
+    setEditTextState(true);
+    setEditText(displayText);
+  };
+
+  const handleCancelEdit = () => {
+    setEditTextState(false)
+  }
+
+  // Save the text to the backend
+  const handleSaveEdit = () => {
+    setDisplayText(editText.trim())
+    setEditTextState(false)
+    //handleSaveChat(localEditedText, setEditingText, setCenterCoordinates, setLoading, setJsonData, setMarkers, setLocalEditedText, prevEditedTextRef);
+  };
+
+  const handleSendNewText = () => {
+    // Send inputNewText
+  }
+
+
+  return (
+    <aside className="w-1/3 border-r flex flex-col">
+      <div className="p-2 px-4 flex items-center justify-between border-b dark:border-b-gray-600 dark:bg-slate-900">
+        <div className="items-center">
+          {numberOfLocations} Locations
+        </div>
+        <Button
+          onClick={handleEditClick}
+          variant="secondary"
+          className="flex items-center justify-center"
+          disabled={editTextState}
+        >
+          <Pencil className="inline w-5 h-5 mr-2" />Edit text
+        </Button>
+      </div>
+      <div className="flex flex-col h-full">
+        <ScrollArea>
+          <div className="px-3 py-5 dark:text-white">
+            {loading ? (
+              <Bbl />
+            ) : (
+              <div className="whitespace-pre-wrap">
+                {props.displayState === 1 && editTextState &&
+                  // Textarea displayed for chat
+                  <Textarea
+                    name="EditChat"
+                    value={editText}
+                    rows={1}
+                    onChange={handleChange}
+                    ref={editInputRef}
+                  />
+                }
+                {props.displayState === 2 &&
+                  // Textarea displayed for manual text
+                  <Textarea
+                    name="DisplayEditText"
+                    value={editText}
+                    rows={5}
+                    hiddenState={editTextState ? 0 : 1}
+                    onChange={handleChange}
+                    ref={editInputRef}
+                    readOnly={!editTextState}
+                  />
+                }
+                {editTextState &&
+                  <div className="flex pt-2 mb-4 space-x-4">
+                    <Button onClick={handleCancelEdit} variant="secondary">
+                      Cancel
+                    </Button>
+                    <Button onClick={handleSaveEdit} variant="blue">
+                      Save
+                    </Button>
+                  </div>
+                }
+
+                {props.displayState === 1 &&
+                  // DisplayState 2 for chat
+                  <>
+                    <JsonRenderer jsonData={jsonData} />
+                  </>
+                }
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+        <div className="p-3 flex justify-center mt-auto space-x-2">
+          <Input
+            name="ChatInput"
+            placeholder={props.displayState === 2 ? "Type your message here..." : "Add more text here..."}
+            type="text"
+            value={inputNewText}
+            onChange={(e) => setInputNewText(e.target.value)}
+          />
+          <Button variant="secondary" onClick={handleSendNewText} disabled={inputNewText?.trim() === ""}>
+            Send
+          </Button>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+export { InputDisplay }

--- a/frontend/components/component/inputDisplay.tsx
+++ b/frontend/components/component/inputDisplay.tsx
@@ -63,7 +63,7 @@ const InputDisplay = (props: InputDisplayProps) => {
   };
 
   const handleAddToChat = () => {
-    // Send inputNewText
+    // Send inputNewText only if the displaystate is ment to display the field
     if (props.displayState === 1 && props.onSendRequest) {
       props.onSendRequest(newText);
       setNewText("");
@@ -86,11 +86,10 @@ const InputDisplay = (props: InputDisplayProps) => {
           <Pencil className="inline w-5 h-5 mr-2" />Edit text
         </Button>
       </div>
-      <div className="overflow-y-auto scroll_overflow_shadow" style={{ boxShadow: 'rgb(31, 41, 55) 0px -30px 15px -20px inset' }}>
-        <div className=" dark:text-white">
           {props.loading ? (
             <Bbl />
           ) : (
+        <div className="dark:text-white overflow-y-auto scroll_overflow_shadow">
             <div className="whitespace-pre-wrap">
               {(props.displayState === 1 || props.displayState === 2) &&
                 // Textarea displayed for editing text or main chat input
@@ -137,10 +136,10 @@ const InputDisplay = (props: InputDisplayProps) => {
                 </>
               }
             </div>
-          )}
         </div>
+      )}
 
-      </div>
+
       {props.displayState === 1 &&
         // Displays ChatInput when displaying chat
         <div className="p-3 flex justify-center mt-auto space-x-2">

--- a/frontend/components/component/mapComponent.tsx
+++ b/frontend/components/component/mapComponent.tsx
@@ -11,7 +11,7 @@ import { EditMarker } from '../component/edit-marker';
  */
 type MapComponentProps = {
   markers: { latitude: number; longitude: number; type: string }[];
-  centerCoordinates: [number, number] | null;
+  //centerCoordinates: [number, number] | null;
   selectedMarkerIndex: number | null;
   setSelectedMarkerIndex: React.Dispatch<React.SetStateAction<number | null>>;
   geojsonData?: any;
@@ -22,7 +22,6 @@ type MapComponentProps = {
  * Map Component for displaying map with added formatting
  * 
  * @param markers 
- * @param centerCoordinates 
  * @param selectedMarkerIndex 
  * @param setSelectedMarkerIndex 
  * @param geojsonData 
@@ -30,7 +29,6 @@ type MapComponentProps = {
  */
 const MapComponent: React.FC<MapComponentProps> = ({
   markers: markersProp,
-  centerCoordinates,
   selectedMarkerIndex,
   setSelectedMarkerIndex,
   geojsonData,
@@ -87,11 +85,12 @@ const MapComponent: React.FC<MapComponentProps> = ({
 
   // Run once when centerCoorcinates changes, then fly to coordinates.
   useEffect(() => {
-    if (mapRef.current && centerCoordinates != null) {
-      console.log('Flying to: ', centerCoordinates);
-      mapRef.current.flyTo({ center: centerCoordinates, zoom: 4 });
+    if (mapRef.current && markers != null) {
+      let firstPoint: [number, number] = [markers[0].longitude, markers[0].latitude];
+      console.log('Flying to: ', firstPoint);
+      mapRef.current.flyTo({ center: firstPoint, zoom: 4 });
     }
-  }, [centerCoordinates])
+  }, [markers])
 
   return (
     <ReactMapGL

--- a/frontend/components/component/startChatGPt.tsx
+++ b/frontend/components/component/startChatGPt.tsx
@@ -1,113 +1,114 @@
 import { Button } from "@/components/ui/button";
-import { useReducer, useState } from "react"; // Import the useReducer hook
+import { useState } from "react";
 import AskingView from "./askingView";
 import { Toolbar } from "../ui/toolbar";
 import { Textarea } from "../ui/textarea";
 
-const initialState = { asking: false, editedText: '', textareaValue: '' };
-
-// Define the reducer function
-function reducer(state: any, action: any) {
-  switch (action.type) {
-    case 'SET_TEXTAREA_VALUE':
-      return { ...state, textareaValue: action.value };
-    case 'ASK':
-      return { ...state, asking: true, editedText: action.value };
-    case 'DISCARD':
-      return { ...state, asking: false, editedText: '', textareaValue: '' };
-    default:
-      throw new Error();
-  }
-}
 
 // Define the StartChatGPt component
 export default function StartChatGPt() {
-  const [state, dispatch] = useReducer(reducer, initialState); // Use the useReducer hook
   const [geoJsonPath, setGeoJsonPath] = useState<string | null>(null);
-  const [markers, setMarkersToolbar] = useState<{ latitude: number; longitude: number; type: string;}[]>([]);
+  const [markers, setMarkersToolbar] = useState<{ latitude: number; longitude: number; type: string; }[]>([]);
+  const [textareaValue, setTextareaValue] = useState("");
+  const [inputText, setInputText] = useState("");
+  const [askigState, setAskingState] = useState(false);
 
   // Handler for the onEditSave prop
-  const handleEditSave = (text: string) => {
-    console.log('handleEditSave called. text:', text);
-    dispatch({ type: 'ASK', value: text }); // Update editedText using dispatch
+  const saveEditText = (text: string) => {
+    console.log("SaveEditText called. text:", text);
+    
+    // Do nothing if new text is same as old
+    if(text == inputText) {
+      console.log("New text was same as old one. No need to repeat request.");
+      return;
+    }
+    setInputText(text);
+    setAskingState(true);
   };
-  
+
   // Handler for the textarea change event
   const handleTextareaChange = (e: any) => {
-    dispatch({ type: 'SET_TEXTAREA_VALUE', value: e.target.value });
+    setTextareaValue(e.target.value);
   };
 
   // Handler for the Ask button click event
   const handleAskButtonClick = () => {
-    if (state.textareaValue.trim() !== "") {
-      dispatch({ type: 'ASK', value: state.textareaValue });
+    if (textareaValue.trim() !== "") {
+      setInputText(textareaValue);
+      setAskingState(true);
     }
   };
 
+  // Handler for discarding and returning to start
   const handleDiscard = () => {
-    dispatch({ type: 'DISCARD' });
+    setTextareaValue("");
+    setInputText("");
+    setAskingState(false);
   }
 
-    return (
-        <div>
-            <Toolbar
-                viewAllOptions={state.asking}
-                onDiscardClick={handleDiscard}
-                geoJsonPath={geoJsonPath}
-                markers={markers}
-            />
-            {state.asking ? (
-                // Pass the handleEditSave function as the onEditSave prop
-                <AskingView onEditSave={handleEditSave} editedText={state.editedText} setGeoJsonPath={setGeoJsonPath} setMarkersToolbar={setMarkersToolbar}/>
-            ) : (
-                <>
-                <div>
-                    <div className="max-w-4xl mx-auto my-12 mt-4 p-8 dark:text-gray-300">
-                        <h1 className="text-3xl font-bold text-center mb-6">Create a map from an ask</h1>
-                        <div className="flex flex-col lg:flex-row justify-between gap-8">
-                            <div className="flex-1">
-                                <h2 className="text-xl font-semibold mb-4">Examples of what you can ask:</h2>
-                                <ul className="list-disc pl-5 space-y-2">
-                                    <li>What should I see when visiting Paris?</li>
-                                    <li>What are the highest mountains in the world?</li>
-                                    <li>Which countries took part in WW2?</li>
-                                    <li>Where are bananas grown?</li>
-                                    <li>Where are the best surfing spots in California?</li>
-                                </ul>
-                            </div>
-                            <div className="flex-1">
-                                <h2 className="text-xl font-semibold mb-4">Limitations</h2>
-                                <ul className="list-disc pl-5 space-y-2">
-                                    <li>Limited knowledge up to 2021</li>
-                                    <li>May find locations in other places than intended</li>
-                                    <li>Limited to bounderies gathered from geoBounderies</li>
-                                </ul>
-                            </div>
-                        </div>
-                        <div className="mt-8">
-                            {/* <form className="flex flex-col items-center"> */}
-                                <Textarea
-                                    name="TextAreaInput"
-                                    className="mb-4"
-                                    placeholder="Ask a question"
-                                    value={state.textareaValue}
-                                    onChange={handleTextareaChange}
-                                />
-                                <Button
-                                    className={`w-full ${state.textareaValue.trim() === "" ? "bg-gray-500 cursor-not-allowed " : ""}`}
-                                    variant={"blue"}
-                                    onClick={handleAskButtonClick}
-                                    disabled={state.textareaValue.trim() === ""}
-                                >
-                                    Ask ChatGPT
-                                </Button>
-                            {/* </form> */}
-                            <p className="text-center text-sm text-gray-500 mt-4">Question + Answer is limited to 1000 words</p>
-                        </div>
-                    </div>
-                    </div>
-                </>
-            )}
-        </div>
-    )
+  return (
+    <div>
+      <Toolbar
+        viewAllOptions={askigState}
+        onDiscardClick={handleDiscard}
+        geoJsonPath={geoJsonPath}
+        markers={markers}
+      />
+      {askigState ? (
+        <AskingView
+          inputText={inputText}
+          onSaveEditText={saveEditText}
+          setGeoJsonPath={setGeoJsonPath}
+          setMarkersToolbar={setMarkersToolbar} />
+      ) : (
+        <>
+          <div>
+            <div className="max-w-4xl mx-auto my-12 mt-4 p-8 dark:text-gray-300">
+              <h1 className="text-3xl font-bold text-center mb-6">Create a map from an ask</h1>
+              <div className="flex flex-col lg:flex-row justify-between gap-8">
+                <div className="flex-1">
+                  <h2 className="text-xl font-semibold mb-4">Examples of what you can ask:</h2>
+                  <ul className="list-disc pl-5 space-y-2">
+                    <li>What should I see when visiting Paris?</li>
+                    <li>What are the highest mountains in the world?</li>
+                    <li>Which countries took part in WW2?</li>
+                    <li>Where are bananas grown?</li>
+                    <li>Where are the best surfing spots in California?</li>
+                  </ul>
+                </div>
+                <div className="flex-1">
+                  <h2 className="text-xl font-semibold mb-4">Limitations</h2>
+                  <ul className="list-disc pl-5 space-y-2">
+                    <li>Limited knowledge up to 2021</li>
+                    <li>May find locations in other places than intended</li>
+                    <li>Limited to bounderies gathered from geoBounderies</li>
+                  </ul>
+                </div>
+              </div>
+              <div className="mt-8">
+                {/* <form className="flex flex-col items-center"> */}
+                <Textarea
+                  name="TextAreaInput"
+                  className="mb-4"
+                  placeholder="Ask a question"
+                  value={textareaValue}
+                  onChange={handleTextareaChange}
+                />
+                <Button
+                  className={`w-full ${textareaValue.trim() === "" ? "bg-gray-500 cursor-not-allowed " : ""}`}
+                  variant={"blue"}
+                  onClick={handleAskButtonClick}
+                  disabled={textareaValue.trim() === ""}
+                >
+                  Ask ChatGPT
+                </Button>
+                {/* </form> */}
+                <p className="text-center text-sm text-gray-500 mt-4">Question + Answer is limited to 1000 words</p>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
 }

--- a/frontend/components/component/startDataSourceInput.tsx
+++ b/frontend/components/component/startDataSourceInput.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
+import { Button } from "../ui/button";
+import { Textarea } from "../ui/textarea";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { handleSendTextInput } from "../functions/ApiUtils";
@@ -7,7 +7,7 @@ import { ScrollArea } from "../ui/scroll-area";
 import { ArrowLongIcon, UploadIcon } from "../ui/icons";
 import { Toolbar } from "../ui/toolbar";
 import MapComponent from "./mapComponent";
-import Navbar from "@/components/ui/navbar";
+import { InputDisplay } from "../component/inputDisplay";
 
 export default function StartDataSource() {
   const maxLengthInput = 3000; // Max length for input
@@ -115,8 +115,8 @@ export default function StartDataSource() {
               <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-1 inline-flex gap-1">
                 <button
                   className={`rounded-lg border ${textSource
-                      ? "bg-white dark:bg-slate-800 text-blue-500 border-blue-500 border-underline-blue"
-                      : "border-gray-100 dark:border-gray-800 dark:text-gray-400"
+                    ? "bg-white dark:bg-slate-800 text-blue-500 border-blue-500 border-underline-blue"
+                    : "border-gray-100 dark:border-gray-800 dark:text-gray-400"
                     }`}
                   disabled={textSource}
                   onClick={handleInputToggle}
@@ -125,8 +125,8 @@ export default function StartDataSource() {
                 </button>
                 <button
                   className={`rounded-lg border ${!textSource
-                      ? "bg-white dark:bg-slate-800 border-blue-500 text-blue-500 border-underline-blue"
-                      : "border-gray-100 dark:border-gray-800 dark:text-gray-500"
+                    ? "bg-white dark:bg-slate-800 border-blue-500 text-blue-500 border-underline-blue"
+                    : "border-gray-100 dark:border-gray-800 dark:text-gray-500"
                     }`}
                   disabled={!textSource}
                   onClick={handleInputToggle}
@@ -163,8 +163,8 @@ export default function StartDataSource() {
                     <div className="text-sm text-gray-600 dark:text-gray-300">
                       <span
                         className={`${textareaValue.trim().length > maxLengthInput
-                            ? "text-red-500"
-                            : ""
+                          ? "text-red-500"
+                          : ""
                           }`}
                       >
                         {textareaValue.trim().length}/{maxLengthInput}{" "}
@@ -174,9 +174,9 @@ export default function StartDataSource() {
                     <div>
                       <Button
                         className={`w-full transition ${textareaValue.trim() === "" ||
-                            textareaValue.trim().length > maxLengthInput
-                            ? "bg-gray-500"
-                            : ""
+                          textareaValue.trim().length > maxLengthInput
+                          ? "bg-gray-500"
+                          : ""
                           }`}
                         variant={"blue"}
                         onClick={handleInputButtonClick}
@@ -257,14 +257,12 @@ export default function StartDataSource() {
       ) : (
         <div className="bg-white dark:bg-gray-800 dark:text-white overflow-y-auto">
           <div className="flex">
-            <aside
-              className="w-1/3 p-4 space-y-4 border-r flex flex-col"
-              style={{ flex: "0 0 auto", height: "calc(100vh - 57px)" }}
-            >
-              <ScrollArea>
-                <div>{inputText}</div>
-              </ScrollArea>
-            </aside>
+            <InputDisplay
+              displayState={2} // For manual text-input
+              input={inputText}
+              jsonData={jsonData}
+              markers={markers}
+            />
             <main className="flex-auto relative w-2/3">
               <div style={{ height: "calc(100vh - 57px)" }}>
                 <MapComponent

--- a/frontend/components/component/startDataSourceInput.tsx
+++ b/frontend/components/component/startDataSourceInput.tsx
@@ -3,7 +3,6 @@ import { Textarea } from "../ui/textarea";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { handleSendTextInput } from "../functions/ApiUtils";
-import { ScrollArea } from "../ui/scroll-area";
 import { ArrowLongIcon, UploadIcon } from "../ui/icons";
 import { Toolbar } from "../ui/toolbar";
 import MapComponent from "./mapComponent";
@@ -18,18 +17,11 @@ export default function StartDataSource() {
   const [mapView, setMapView] = useState(false);
   const [textSource, toggleTextSource] = useState(true);
   const [inputText, setInputText] = useState("");
-  const [newInputText, setNewInputText] = useState("");
   const [textareaValue, setTextareaValue] = useState("");
-  // const [textareaValue, setTextareaValue] = useState(() => {
-  //     const savedText = localStorage.getItem('textValue');
-  //     return savedText || '';
-  // });
   const [uploadedFile, setUploadedFile] = useState(false);
 
   const [jsonData, setJsonData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
-  const [editingText, setEditingText] = useState(false);
-  const [localEditedText, setLocalEditedText] = useState("");
   const [markers, setMarkers] = useState<
     { latitude: number; longitude: number; type: string }[]
   >([]);
@@ -38,9 +30,10 @@ export default function StartDataSource() {
   );
 
 
+  // Handle for processing a given input
   const handleInputButtonClick = (input: string) => {
     if (textSource && input.trim() !== "") {
-      console.log("Trimmed input is not empty, so create map!");
+      console.log("Recieved text! Creating map!");
       setInputText(input);
       handlePostText(input);
       setMapView(true);
@@ -69,20 +62,14 @@ export default function StartDataSource() {
     setMapView(false);
   };
 
+  // handler for posting a given text to the backend
   const handlePostText = (text: string) => {
-    // Commented out for debugging
-    
-    // handleSendTextInput(
-    //   text,
-    //   setJsonData,
-    //   setMarkers,
-    //   setLoading
-    // );
-    setLoading(false); // Added for debugging
-  };
-
-  const handleEditClick = () => {
-    setEditingText(true);
+    handleSendTextInput(
+      text,
+      setJsonData,
+      setMarkers,
+      setLoading
+    );
   };
 
   // Ask user if he wants to reload the page
@@ -247,7 +234,7 @@ export default function StartDataSource() {
         <div className="bg-white dark:bg-gray-800 dark:text-white overflow-y-auto">
           <div className="flex">
             <InputDisplay
-              displayState={2} // For manual text-input
+              displayState={2} // 2 for manual text-input
               loading={loading}
               input={inputText}
               jsonData={jsonData}

--- a/frontend/components/component/startDataSourceInput.tsx
+++ b/frontend/components/component/startDataSourceInput.tsx
@@ -36,9 +36,6 @@ export default function StartDataSource() {
   const [selectedMarkerIndex, setSelectedMarkerIndex] = useState<number | null>(
     null
   );
-  const [centerCoordinates, setCenterCoordinates] = useState<
-    [number, number] | null
-  >(null);
 
   const handleTextareaChange = (e: any) => {
     setTextareaValue(e.target.value);
@@ -80,7 +77,6 @@ export default function StartDataSource() {
     handleSendTextInput(
       text,
       setJsonData,
-      setCenterCoordinates,
       setMarkers,
       setLoading
     );
@@ -267,7 +263,6 @@ export default function StartDataSource() {
               <div style={{ height: "calc(100vh - 57px)" }}>
                 <MapComponent
                   markers={markers}
-                  centerCoordinates={centerCoordinates}
                   selectedMarkerIndex={selectedMarkerIndex}
                   setSelectedMarkerIndex={setSelectedMarkerIndex}
                   geojsonData={jsonData?.selected_countries_geojson_path}

--- a/frontend/components/component/startDataSourceInput.tsx
+++ b/frontend/components/component/startDataSourceInput.tsx
@@ -37,16 +37,12 @@ export default function StartDataSource() {
     null
   );
 
-  const handleTextareaChange = (e: any) => {
-    setTextareaValue(e.target.value);
-    //localStorage.setItem('textValue', e.target.value);
-  };
 
-  const handleInputButtonClick = () => {
-    if (textSource && textareaValue.trim() !== "") {
+  const handleInputButtonClick = (input: string) => {
+    if (textSource && input.trim() !== "") {
       console.log("Trimmed input is not empty, so create map!");
-      setInputText(textareaValue);
-      handlePostText(textareaValue);
+      setInputText(input);
+      handlePostText(input);
       setMapView(true);
     } else if (!textSource && uploadedFile) {
       console.log("File uploaded. Generate map!");
@@ -74,14 +70,15 @@ export default function StartDataSource() {
   };
 
   const handlePostText = (text: string) => {
-    handleSendTextInput(
-      text,
-      setJsonData,
-      setMarkers,
-      setLoading
-    );
-
-    //setInputText("");
+    // Commented out for debugging
+    
+    // handleSendTextInput(
+    //   text,
+    //   setJsonData,
+    //   setMarkers,
+    //   setLoading
+    // );
+    setLoading(false); // Added for debugging
   };
 
   const handleEditClick = () => {
@@ -95,10 +92,6 @@ export default function StartDataSource() {
       window.onbeforeunload = null;
     };
   }, []);
-
-  // const handleSaveTextWrapper = () => {
-  //     handleSaveChat(localEditedText, setEditingText, setLoading, setJsonData, setMarkers, setLocalEditedText, prevEditedTextRef);
-  // };
 
   return (
     <div>
@@ -153,7 +146,7 @@ export default function StartDataSource() {
                     className="mb-4"
                     placeholder="Aa"
                     value={textareaValue}
-                    onChange={handleTextareaChange}
+                    onChange={(e) => setTextareaValue(e.target.value)}
                   />
                   <div className="flex w-full center justify-between">
                     <div className="text-sm text-gray-600 dark:text-gray-300">
@@ -175,7 +168,7 @@ export default function StartDataSource() {
                           : ""
                           }`}
                         variant={"blue"}
-                        onClick={handleInputButtonClick}
+                        onClick={() => handleInputButtonClick(textareaValue)}
                         disabled={
                           textareaValue.trim() === "" ||
                           textareaValue.trim().length > maxLengthInput
@@ -232,7 +225,7 @@ export default function StartDataSource() {
                       className={`w-full transition ${!uploadedFile ? "bg-gray-500 cursor-not-allowed" : ""
                         }`}
                       variant={"blue"}
-                      onClick={handleInputButtonClick}
+                      onClick={() => handleInputButtonClick(textareaValue)}
                       disabled={!uploadedFile}
                     >
                       Generate Map
@@ -255,9 +248,11 @@ export default function StartDataSource() {
           <div className="flex">
             <InputDisplay
               displayState={2} // For manual text-input
+              loading={loading}
               input={inputText}
               jsonData={jsonData}
               markers={markers}
+              onSaveEditText={handleInputButtonClick}
             />
             <main className="flex-auto relative w-2/3">
               <div style={{ height: "calc(100vh - 57px)" }}>

--- a/frontend/components/functions/ApiUtils.ts
+++ b/frontend/components/functions/ApiUtils.ts
@@ -7,7 +7,6 @@ export const handleDataFetching = async (
     url: string,
     payload: any,
     setJsonData: React.Dispatch<React.SetStateAction<any>>,
-    setCenter: React.Dispatch<React.SetStateAction<[number, number] | null>>,
     setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
     setLoading: React.Dispatch<React.SetStateAction<boolean>>,
     setLocalEditedText?: React.Dispatch<React.SetStateAction<string>>,
@@ -61,11 +60,6 @@ export const handleDataFetching = async (
             let center: [number, number] = [centerCoordinates[0], centerCoordinates[1]];
              setCenter(center);
              */
-
-            // This is a quick cange to put the first coordinate set as the focus-point on the map.
-            let firstPoint = coordinatesArray[0];
-            let center: [number, number] = [firstPoint[0],firstPoint[1]];
-            setCenter(center);
             
             // Proceed with the rest of your logic, e.g., extracting coordinates, setting markers, etc.
 
@@ -104,7 +98,6 @@ export const handleDataFetching = async (
 export const handleSaveChat = async (
     localEditedText: string,
     setEditingText: React.Dispatch<React.SetStateAction<boolean>>,
-    setCenter: React.Dispatch<React.SetStateAction<[number, number] | null>>,
     setLoading: React.Dispatch<React.SetStateAction<boolean>>,
     setJsonData: React.Dispatch<React.SetStateAction<any>>,
     setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
@@ -117,7 +110,6 @@ export const handleSaveChat = async (
             `${BASE_URL}/newChat?message=${localEditedText}`,
             { editedText: localEditedText },
             setJsonData,
-            setCenter,
             setMarkers,
             setLoading,
             setLocalEditedText
@@ -140,7 +132,6 @@ export const handleSaveChat = async (
 export const handleSendChat = async (
     inputText: string,
     setJsonData: React.Dispatch<React.SetStateAction<any>>,
-    setCenter: React.Dispatch<React.SetStateAction<[number, number] | null>>,
     setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
     setInputText: React.Dispatch<React.SetStateAction<string>>,
     setLoading: React.Dispatch<React.SetStateAction<boolean>>
@@ -153,7 +144,6 @@ export const handleSendChat = async (
             `${BASE_URL}/moreChat?message=${inputText}&thread_id=${thread_id}`,
             { inputText },
             setJsonData,
-            setCenter,
             setMarkers,
             setLoading,
             // Set the input text to empty after sending the request
@@ -168,7 +158,6 @@ export const handleSendChat = async (
 export const handleSendTextInput = async (
     inputText: string,
     setJsonData: React.Dispatch<React.SetStateAction<any>>,
-    setCenter: React.Dispatch<React.SetStateAction<[number, number] | null>>,
     setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
     setLoading: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
@@ -177,7 +166,6 @@ export const handleSendTextInput = async (
             `${BASE_URL}/newText?text=${inputText}`,
             { inputText },
             setJsonData,
-            setCenter,
             setMarkers,
             setLoading
         );

--- a/frontend/components/functions/ApiUtils.ts
+++ b/frontend/components/functions/ApiUtils.ts
@@ -4,173 +4,156 @@ import axios from 'axios';
 const BASE_URL = "http://localhost:8000";
 
 export const handleDataFetching = async (
-    url: string,
-    payload: any,
-    setJsonData: React.Dispatch<React.SetStateAction<any>>,
-    setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
-    setLoading: React.Dispatch<React.SetStateAction<boolean>>,
-    setLocalEditedText?: React.Dispatch<React.SetStateAction<string>>,
-    additionalLogic?: (data: any) => void
+  url: string,
+  payload: any,
+  setJsonData: React.Dispatch<React.SetStateAction<any>>,
+  setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>,
+  additionalLogic?: (data: any) => void
 ) => {
-    setLoading(true);
+  setLoading(true);
 
-    try {
-        const response = await axios.post(url, payload, {
-            headers: {
-                'Content-Type': 'application/json',
-            },
-        });
+  try {
+    const response = await axios.post(url, payload, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
 
-        const data = response.data;
-        setJsonData(data);
+    const data = response.data;
+    setJsonData(data);
 
-        console.log('JSON data from the backend:', data);
+    console.log('JSON data from the backend:', data);
 
-        // If a GeoJSON path is provided, fetch the GeoJSON data
-        if (data.selected_countries_geojson_path) {
-            const geoJsonData = data.selected_countries_geojson_path;
+    // If a GeoJSON path is provided, fetch the GeoJSON data
+    if (data.selected_countries_geojson_path) {
+      const geoJsonData = data.selected_countries_geojson_path;
 
-            // Now you have the GeoJSON data
-            console.log('GeoJSON data:', geoJsonData);
+      // Now you have the GeoJSON data
+      console.log('GeoJSON data:', geoJsonData);
 
-            // Extract entities and filter out unnecessary strings
-            const filteredEntities = data.entities
-                .map((entry: any) => entry.filter((item: any) => Array.isArray(item) && item.length === 2))
-                .flat();
+      // Extract entities and filter out unnecessary strings
+      const filteredEntities = data.entities
+        .map((entry: any) => entry.filter((item: any) => Array.isArray(item) && item.length === 2))
+        .flat();
 
-            console.log('Filtered Entities:', filteredEntities);
+      console.log('Filtered Entities:', filteredEntities);
 
-            const coordinates: Coordinate[] = extractCoordinates(filteredEntities);
-            console.log('Extracted Coordinates:', coordinates);
+      const coordinates: Coordinate[] = extractCoordinates(filteredEntities);
+      console.log('Extracted Coordinates:', coordinates);
 
-            // place the markers on the map
-            const coordinatesArray = coordinates.map((coordinate) => [coordinate.longitude, coordinate.latitude]);
-            console.log('Coordinates Array:', coordinatesArray);
+      // place the markers on the map
+      const coordinatesArray = coordinates.map((coordinate) => [coordinate.longitude, coordinate.latitude]);
+      console.log('Coordinates Array:', coordinatesArray);
 
-            // Calculate the center coordinates
-            const centerCoordinates = coordinatesArray.reduce(
-                (accumulator, currentValue) => [accumulator[0] + currentValue[0], accumulator[1] + currentValue[1]],
-                [0, 0]
-            );
-            
-            console.log('Center Coordinates:', centerCoordinates);
+      // Calculate the center coordinates
+      const centerCoordinates = coordinatesArray.reduce(
+        (accumulator, currentValue) => [accumulator[0] + currentValue[0], accumulator[1] + currentValue[1]],
+        [0, 0]
+      );
 
-            // An odd convertion to ensure that centerCoordinates is a tuple of two numbers; a type of [number, number] instead of number[].
-            /* 
-            let center: [number, number] = [centerCoordinates[0], centerCoordinates[1]];
-             setCenter(center);
-             */
-            
-            // Proceed with the rest of your logic, e.g., extracting coordinates, setting markers, etc.
+      console.log('Center Coordinates:', centerCoordinates);
 
-            setJsonData(data);
-            setMarkers(coordinates as { latitude: number; longitude: number; type: string }[]);
+      // An odd convertion to ensure that centerCoordinates is a tuple of two numbers; a type of [number, number] instead of number[].
+      /* 
+      let center: [number, number] = [centerCoordinates[0], centerCoordinates[1]];
+       setCenter(center);
+       */
 
-            if (setLocalEditedText) {
-                setLocalEditedText(payload.editedText);
-            }
+      // Proceed with the rest of your logic, e.g., extracting coordinates, setting markers, etc.
 
-            if (additionalLogic) {
-                additionalLogic(data);
-            }
+      setJsonData(data);
+      setMarkers(coordinates as { latitude: number; longitude: number; type: string }[]);
 
-            setLoading(false);
-        } else {
-            // Handle the case where no GeoJSON path is provided in the backend response
-            console.error('No GeoJSON path provided in the backend response.');
+      if (additionalLogic) {
+        additionalLogic(data);
+      }
 
-            // Set loading to false
-            setLoading(false);
-        }
-        return data;
+      setLoading(false);
+    } else {
+      // Handle the case where no GeoJSON path is provided in the backend response
+      console.error('No GeoJSON path provided in the backend response.');
+
+      // Set loading to false
+      setLoading(false);
     }
-    catch (error) {
-        console.error('Error fetching JSON data:', error);
+    return data;
+  }
+  catch (error) {
+    console.error('Error fetching JSON data:', error);
 
-        if (setLocalEditedText) {
-            setLocalEditedText(payload.editedText);
-        }
-
-        setLoading(false);
-    }
+    setLoading(false);
+  }
 };
 
 export const handleSaveChat = async (
-    localEditedText: string,
-    setEditingText: React.Dispatch<React.SetStateAction<boolean>>,
-    setLoading: React.Dispatch<React.SetStateAction<boolean>>,
-    setJsonData: React.Dispatch<React.SetStateAction<any>>,
-    setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
-    setLocalEditedText: React.Dispatch<React.SetStateAction<string>>,
-    prevEditedTextRef: React.MutableRefObject<string | undefined>
+  inputText: string,
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>,
+  setJsonData: React.Dispatch<React.SetStateAction<any>>,
+  setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
 ) => {
-    if (localEditedText !== prevEditedTextRef.current) {
-        setEditingText(false);
-        const responseData = await handleDataFetching(
-            `${BASE_URL}/newChat?message=${localEditedText}`,
-            { editedText: localEditedText },
-            setJsonData,
-            setMarkers,
-            setLoading,
-            setLocalEditedText
-        );
+  if (inputText.trim() !== '') {
+    const responseData = await handleDataFetching(
+      `${BASE_URL}/newChat?message=${inputText}`,
+      { editedText: inputText },
+      setJsonData,
+      setMarkers,
+      setLoading,
+    );
 
-        console.log('Response data:', responseData);
+    console.log('Response data:', responseData);
 
-        const threadId = responseData.thread_id;
-        if(!threadId)   {
-            console.error('No threadId provided in the backend response.');
-            return;
-        } else {
-            document.cookie = `threadId=${threadId}; path=/; max-age=31536000`;
-            console.log('threadId:', threadId);
-        }
+    const threadId = responseData.thread_id;
+    if (!threadId) {
+      console.error('No threadId provided in the backend response.');
+      return;
+    } else {
+      document.cookie = `threadId=${threadId}; path=/; max-age=31536000`;
+      console.log('threadId:', threadId);
     }
+  }
 };
 
 
 export const handleSendChat = async (
-    inputText: string,
-    setJsonData: React.Dispatch<React.SetStateAction<any>>,
-    setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
-    setInputText: React.Dispatch<React.SetStateAction<string>>,
-    setLoading: React.Dispatch<React.SetStateAction<boolean>>
+  inputText: string,
+  setJsonData: React.Dispatch<React.SetStateAction<any>>,
+  setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
-    if (inputText.trim() !== '') {
-        // Get all cookies and split them by semicolon. Find the first row starting with desired cookie-name, then ceep only value after equals-sign.
-        let thread_id = document.cookie.split('; ').find((row) => row.startsWith('threadId='))?.split('=')[1];
-        
-        await handleDataFetching(
-            `${BASE_URL}/moreChat?message=${inputText}&thread_id=${thread_id}`,
-            { inputText },
-            setJsonData,
-            setMarkers,
-            setLoading,
-            // Set the input text to empty after sending the request
-            setInputText
-        );
-    } else {
-        // Handle case where inputText is empty
-        console.log('Input text is empty. Not sending the request.');
-    }
+  if (inputText.trim() !== '') {
+    // Get all cookies and split them by semicolon. Find the first row starting with desired cookie-name, then ceep only value after equals-sign.
+    let thread_id = document.cookie.split('; ').find((row) => row.startsWith('threadId='))?.split('=')[1];
+
+    await handleDataFetching(
+      `${BASE_URL}/moreChat?message=${inputText}&thread_id=${thread_id}`,
+      { inputText },
+      setJsonData,
+      setMarkers,
+      setLoading,
+    );
+  } else {
+    // Handle case where inputText is empty
+    console.log('Input text is empty. Not sending the request.');
+  }
 };
 
 export const handleSendTextInput = async (
-    inputText: string,
-    setJsonData: React.Dispatch<React.SetStateAction<any>>,
-    setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
-    setLoading: React.Dispatch<React.SetStateAction<boolean>>
+  inputText: string,
+  setJsonData: React.Dispatch<React.SetStateAction<any>>,
+  setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
-    if (inputText.trim() !== '') {
-        await handleDataFetching(
-            `${BASE_URL}/newText?text=${inputText}`,
-            { inputText },
-            setJsonData,
-            setMarkers,
-            setLoading
-        );
-    } else {
-        // Handle case where inputText is empty
-        console.log('Input text is empty. Not sending the request.');
-    }
+  if (inputText.trim() !== '') {
+    await handleDataFetching(
+      `${BASE_URL}/newText?text=${inputText}`,
+      { inputText },
+      setJsonData,
+      setMarkers,
+      setLoading
+    );
+  } else {
+    // Handle case where inputText is empty
+    console.log('Input text is empty. Not sending the request.');
+  }
 };

--- a/frontend/components/functions/ApiUtils.ts
+++ b/frontend/components/functions/ApiUtils.ts
@@ -32,33 +32,14 @@ export const handleDataFetching = async (
       // Now you have the GeoJSON data
       console.log('GeoJSON data:', geoJsonData);
 
-      // Extract entities and filter out unnecessary strings
-      const filteredEntities = data.entities
-        .map((entry: any) => entry.filter((item: any) => Array.isArray(item) && item.length === 2))
-        .flat();
-
-      console.log('Filtered Entities:', filteredEntities);
-
-      const coordinates: Coordinate[] = extractCoordinates(filteredEntities);
-      console.log('Extracted Coordinates:', coordinates);
-
-      // place the markers on the map
-      const coordinatesArray = coordinates.map((coordinate) => [coordinate.longitude, coordinate.latitude]);
-      console.log('Coordinates Array:', coordinatesArray);
-
-      // Calculate the center coordinates
-      const centerCoordinates = coordinatesArray.reduce(
-        (accumulator, currentValue) => [accumulator[0] + currentValue[0], accumulator[1] + currentValue[1]],
-        [0, 0]
+      // Filter out unnecessary strings and extract to coordinates. 
+      const coordinates: Coordinate[] = extractCoordinates(data.entities
+        .map((entry: any) => entry
+        .filter((item: any) => Array
+        .isArray(item) && item.length === 2))
+        .flat()
       );
-
-      console.log('Center Coordinates:', centerCoordinates);
-
-      // An odd convertion to ensure that centerCoordinates is a tuple of two numbers; a type of [number, number] instead of number[].
-      /* 
-      let center: [number, number] = [centerCoordinates[0], centerCoordinates[1]];
-       setCenter(center);
-       */
+      console.log('Extracted Coordinates:', coordinates);
 
       // Proceed with the rest of your logic, e.g., extracting coordinates, setting markers, etc.
 
@@ -86,11 +67,11 @@ export const handleDataFetching = async (
   }
 };
 
-export const handleSaveChat = async (
+export const handleSendChatRequest = async (
   inputText: string,
-  setLoading: React.Dispatch<React.SetStateAction<boolean>>,
   setJsonData: React.Dispatch<React.SetStateAction<any>>,
   setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
   if (inputText.trim() !== '') {
     const responseData = await handleDataFetching(
@@ -115,7 +96,7 @@ export const handleSaveChat = async (
 };
 
 
-export const handleSendChat = async (
+export const handleAddRequestToChat = async (
   inputText: string,
   setJsonData: React.Dispatch<React.SetStateAction<any>>,
   setMarkers: React.Dispatch<React.SetStateAction<{ latitude: number; longitude: number; type: string }[]>>,

--- a/frontend/components/functions/AutosizeTextArea.ts
+++ b/frontend/components/functions/AutosizeTextArea.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+// Updates the height of a <textarea> when the value changes.
+const autosizeTextArea = (
+  textAreaRef: HTMLTextAreaElement | null,
+  value: string,
+  secondaryUpdateValue?: any
+) => {
+  useEffect(() => {
+    if (textAreaRef) {
+      // Reset the height to get the correct scrollHeight for the textarea
+      textAreaRef.style.height = "0px";
+      const scrollHeight = textAreaRef.scrollHeight;
+
+      // Set the height directly, outside of the render loop
+      textAreaRef.style.height = scrollHeight + 2 + "px";
+    }
+  }, [textAreaRef, value, secondaryUpdateValue]);
+};
+
+export default autosizeTextArea;

--- a/frontend/components/functions/AutosizeTextArea.ts
+++ b/frontend/components/functions/AutosizeTextArea.ts
@@ -3,8 +3,7 @@ import { useEffect } from "react";
 // Updates the height of a <textarea> when the value changes.
 const autosizeTextArea = (
   textAreaRef: HTMLTextAreaElement | null,
-  value: string,
-  secondaryUpdateValue?: any
+  value: string
 ) => {
   useEffect(() => {
     if (textAreaRef) {
@@ -15,7 +14,7 @@ const autosizeTextArea = (
       // Set the height directly, outside of the render loop
       textAreaRef.style.height = scrollHeight + 2 + "px";
     }
-  }, [textAreaRef, value, secondaryUpdateValue]);
+  }, [textAreaRef, value]);
 };
 
 export default autosizeTextArea;

--- a/frontend/components/functions/JsonRenderer.tsx
+++ b/frontend/components/functions/JsonRenderer.tsx
@@ -15,7 +15,10 @@ const JsonRenderer: React.FC<JsonRendererProps> = ({ jsonData }) => {
  if (Array.isArray(chatHistory) && chatHistory.length > 0) {
     const formattedContent = chatHistory.map((item, index) => {
       const role = item.sender === 'user' ? 'User' : 'Assistant';
-      const message = item.message.replace(/  /g, "\n"); // This replaces double spaces with new line
+      const message = item.message
+        .replace(/    /g,'\n') //GPT sometimes returns four spaces followed by a dash. This adds a linebreak to list elements up better.
+        .replace(/(?:(?<!:)  (?!\d+\.))/g,'\n\n') // This adds linebreaks between paragraphs, unless a colon is presented.
+        .replace(/(?:(?<=: ) \d+\.|(?<=\. )\d+\.|(?<=\.  )\d+\.)|(?<=\.   )\d+\./g,'\n$&'); // This adds linebreak for numbered elements and helps to breaks up the returned text.
 
       return <p className="pb-3" key={index}><strong>{role}:</strong> {message}</p>;
     }).reverse();

--- a/frontend/components/functions/JsonRenderer.tsx
+++ b/frontend/components/functions/JsonRenderer.tsx
@@ -16,9 +16,9 @@ const JsonRenderer: React.FC<JsonRendererProps> = ({ jsonData }) => {
     const formattedContent = chatHistory.map((item, index) => {
       const role = item.sender === 'user' ? 'User' : 'Assistant';
       const message = item.message
-        .replace(/    /g,'\n') //GPT sometimes returns four spaces followed by a dash. This adds a linebreak to list elements up better.
+        .replace(/    |(?:(?<=:))  /g,'\n') //GPT sometimes returns four spaces followed by a dash, and sometimes double spaces after colon. This adds a linebreak to list elements up better.
         .replace(/(?:(?<!:)  (?!\d+\.))/g,'\n\n') // This adds linebreaks between paragraphs, unless a colon is presented.
-        .replace(/(?:(?<=: ) \d+\.|(?<=\. )\d+\.|(?<=\.  )\d+\.)|(?<=\.   )\d+\./g,'\n$&'); // This adds linebreak for numbered elements and helps to breaks up the returned text.
+        .replace(/(?:(?<=: )\d+\.|(?<=\. )\d+\.|(?<=\.  )\d+\.)|(?<=\.   )\d+\./g,'\n$&'); // This adds linebreak for numbered elements and helps to breaks up the returned text.
 
       return <p className="pb-3" key={index}><strong>{role}:</strong> {message}</p>;
     }).reverse();

--- a/frontend/components/functions/JsonRenderer.tsx
+++ b/frontend/components/functions/JsonRenderer.tsx
@@ -10,7 +10,7 @@ const JsonRenderer: React.FC<JsonRendererProps> = ({ jsonData }) => {
   }
 
  const gptContent = jsonData.GPT ? <p><strong>GPT:</strong> {jsonData.GPT}</p> : '';
- const chatHistory = jsonData.chat_history;
+ const chatHistory = jsonData.chat_history ?? null;
 
  if (Array.isArray(chatHistory) && chatHistory.length > 0) {
     const formattedContent = chatHistory.map((item, index) => {

--- a/frontend/components/functions/JsonRenderer.tsx
+++ b/frontend/components/functions/JsonRenderer.tsx
@@ -15,7 +15,9 @@ const JsonRenderer: React.FC<JsonRendererProps> = ({ jsonData }) => {
  if (Array.isArray(chatHistory) && chatHistory.length > 0) {
     const formattedContent = chatHistory.map((item, index) => {
       const role = item.sender === 'user' ? 'User' : 'Assistant';
-      return <p className="pb-3" key={index}><strong>{role}:</strong> {item.message}</p>;
+      const message = item.message.replace(/  /g, "\n"); // This replaces double spaces with new line
+
+      return <p className="pb-3" key={index}><strong>{role}:</strong> {message}</p>;
     }).reverse();
 
     // Combine all the React components

--- a/frontend/components/functions/JsonRenderer.tsx
+++ b/frontend/components/functions/JsonRenderer.tsx
@@ -15,8 +15,8 @@ const JsonRenderer: React.FC<JsonRendererProps> = ({ jsonData }) => {
  if (Array.isArray(chatHistory) && chatHistory.length > 0) {
     const formattedContent = chatHistory.map((item, index) => {
       const role = item.sender === 'user' ? 'User' : 'Assistant';
-      return <p key={index}><strong>{role}:</strong> {item.message}</p>;
-    });
+      return <p className="pb-3" key={index}><strong>{role}:</strong> {item.message}</p>;
+    }).reverse();
 
     // Combine all the React components
     const reactContent = [gptContent, ...formattedContent];

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         outline:
           "border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:hover:bg-gray-800 dark:hover:text-gray-50",
         secondary:
-          "bg-gray-100 text-gray-900 hover:bg-gray-100/80 dark:bg-gray-500 dark:text-white dark:hover:bg-gray-500",
+          "bg-gray-200 text-gray-900 hover:bg-gray-200/80 dark:bg-gray-500 dark:text-white dark:hover:bg-gray-600",
         toggle:"bg-blue-500 text-white hover:bg-blue-500/80",
         ghost: "hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-50",
         link: "text-gray-900 underline-offset-4 hover:underline dark:text-gray-50",

--- a/frontend/components/ui/icons.tsx
+++ b/frontend/components/ui/icons.tsx
@@ -129,4 +129,12 @@ const DoubleBubbleIcon = (props: any) => {
     )
 }
 
-export { UploadIcon, DownloadIcon, TextDocumentIcon, DoubleBubbleIcon, ChevronArrowIcon, FatArrowIcon, ArrowLongIcon, TrashHeroIcon, CloseIcon, EditIcon, PaintbrushIcon}
+const Pencil = (props: any) => {
+  return (
+    <svg {...svgParams} {...props} >
+      <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+    </svg>
+  )
+}
+
+export { UploadIcon, DownloadIcon, TextDocumentIcon, DoubleBubbleIcon, ChevronArrowIcon, FatArrowIcon, ArrowLongIcon, TrashHeroIcon, CloseIcon, EditIcon, PaintbrushIcon, Pencil}

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-950 px-3 py-2 text-sm ring-offset-white dark:ring-offset-gray-300 placeholder:text-gray-400 dark:text-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex w-full rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-950 px-3 py-2 text-sm ring-offset-white dark:ring-offset-gray-300 placeholder:text-gray-400 dark:text-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/frontend/components/ui/navbar.tsx
+++ b/frontend/components/ui/navbar.tsx
@@ -26,9 +26,9 @@ const Navbar: React.FC<NavbarProps> = ({ activePage }) => {
             <Link href="/Privacy">Your Data</Link>  
           </button>
 
-          <button className={`btn-nav ${activePage === 'Contact' ? 'btn-nav-active' : ''}`}>
+          {/* <button className={`btn-nav ${activePage === 'Contact' ? 'btn-nav-active' : ''}`}>
             <Link href="/Contact">Contact</Link>  
-          </button>
+          </button> */}
 
           <button className={`btn-nav ${activePage === 'Text & CSV To Map' ? 'btn-nav-active' : ''}`}>
             <Link href="/Text2Map">Image & PDF To Map</Link>

--- a/frontend/components/ui/scroll-area.tsx
+++ b/frontend/components/ui/scroll-area.tsx
@@ -1,27 +1,26 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface ScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {}
+export interface ScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> { }
 
 const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
-    ({ className, ...props }, ref) => {
-        return (
-            <div
-                className={cn("flex flex-col overflow-y-auto scrollbar-hide", className)}
-                style={{
-                    height: "100%",
-                    scrollbarWidth: "thin",
-                    scrollbarColor: "#888888 #f0f0f0",
-                }}
-            >
-                <div
-                    style={{ flex: 1 }}
-                    ref={ref}
-                    {...props}
-                />
-            </div>
-        );
-    }
+  ({ className, ...props }, ref) => {
+    return (
+      <div
+        className={cn("flex flex-col overflow-y-auto scrollbar-hide", className)}
+        style={{
+          scrollbarWidth: "thin",
+          scrollbarColor: "#888888 #f0f0f0",
+        }}
+      >
+        <div
+          style={{ flex: 1 }}
+          ref={ref}
+          {...props}
+        />
+      </div>
+    );
+  }
 );
 
 export { ScrollArea };

--- a/frontend/components/ui/textarea.tsx
+++ b/frontend/components/ui/textarea.tsx
@@ -1,20 +1,27 @@
-import React, { useRef, useState} from "react";
+import React, { useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
 export interface TextareaProps
-  extends React.InputHTMLAttributes<HTMLTextAreaElement> {}
+  extends React.InputHTMLAttributes<HTMLTextAreaElement> {
+  rows?: number,
+  hiddenState?: number
+}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, rows = 1, hiddenState = 0, ...props }, ref) => {
+
     return (
       <textarea
         className={cn(
-          "flex h-10 w-full rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-950 px-3 py-2 text-sm ring-offset-white dark:ring-offset-gray-300 placeholder:text-gray-400 dark:text-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          hiddenState
+            ? "resize-none flex w-full bg-white dark:bg-gray-800 py-2 text-sm ring-offset-0 placeholder:text-gray-400 dark:text-gray-300 focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50"
+            : "flex w-full rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-950 px-3 py-2 text-sm ring-offset-white dark:ring-offset-gray-300 placeholder:text-gray-400 dark:text-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         placeholder="Aa"
         ref={ref}
+        rows={rows}
         {...props}
       />
     )

--- a/frontend/components/ui/toolbar.tsx
+++ b/frontend/components/ui/toolbar.tsx
@@ -105,7 +105,7 @@ const Toolbar = (props: any) => {
     <header className="flex items-center justify-between p-2 px-4 border-b dark:border-b-gray-600 dark:text-gray-300">
       {props.viewAllOptions ? (
         <>
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center gap-4">
             <Button variant="ghost" onClick={() => props.onDiscardClick()}>Discard</Button>
             <input
               type="text"
@@ -115,7 +115,7 @@ const Toolbar = (props: any) => {
               placeholder="Unsaved map"
             />
           </div>
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center gap-4">
             <div className="relative">
               <Button variant="blue" onClick={toggleDropdown}>Export map</Button>
               {dropdownVisible && (
@@ -131,7 +131,7 @@ const Toolbar = (props: any) => {
           </div>
         </>
       ) : (
-        <div className="flex items-center space-x-4">
+        <div className="flex items-center gap-4">
           <Button variant="ghost" onClick={() => router.push("/")}>
             <div className="flex items-center space-x-2">
               <ChevronArrowIcon className="inline-flex h-5 w-5" left={1} />Back

--- a/frontend/components/ui/toolbar.tsx
+++ b/frontend/components/ui/toolbar.tsx
@@ -1,15 +1,23 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { useRouter } from 'next/navigation';
 import { Button } from "./button";
 import { ChevronArrowIcon } from "./icons";
 import FormModal from "./FormModal";
 
+type toolbarProps = {
+  viewAllOptions?: boolean,
+  geoJsonPath?: any,
+  markers?: any,
+  onDiscardClick: () => void,
+  onExportClick?: () => void,
+  onShareClick?: () => void,
+}
+
+
 /**
  * Navbar component
  * 
- * @param {object | any} props Component props
  * @param {boolean} viewAllOptions Viewstate for full or lite toolbar
- * 
  * @param {function} onDiscardClick Discard button callback function
  * @param {function} onExportClick Discard button callback function
  * @param {function} onShareClick Discard button callback function
@@ -17,7 +25,7 @@ import FormModal from "./FormModal";
  * @returns Toolbar
  */
 
-const Toolbar = (props: any) => {
+const Toolbar = (props: toolbarProps) => {
   const router = useRouter();
   const [mapName, setMapName] = useState('Unsaved map'); // State to hold the map name
   const [dropdownVisible, setDropdownVisible] = useState(false); // State to hold the dropdown visibility
@@ -42,6 +50,15 @@ const Toolbar = (props: any) => {
   const handleFeedbackClick = () => {
     setFormModalOpen(true);
   };
+
+  // Opens a confirmation window
+  const handleDiscard = () => {
+    const confirmText = "Do you want to discard current map? Progress will be lost.";
+    if(!window.confirm(confirmText)) return;
+    console.log("Confirmed!");
+    props.onDiscardClick();
+  }
+
 
   const handleExportClickWMarkers = () => {
     if (props.geoJsonPath && props.markers) {
@@ -106,7 +123,7 @@ const Toolbar = (props: any) => {
       {props.viewAllOptions ? (
         <>
           <div className="flex items-center gap-4">
-            <Button variant="ghost" onClick={() => props.onDiscardClick()}>Discard</Button>
+            <Button variant="ghost" onClick={handleDiscard}>Discard</Button>
             <input
               type="text"
               value={mapName}

--- a/frontend/components/ui/toolbar.tsx
+++ b/frontend/components/ui/toolbar.tsx
@@ -18,129 +18,129 @@ import FormModal from "./FormModal";
  */
 
 const Toolbar = (props: any) => {
-    const router = useRouter();
-    const [mapName, setMapName] = useState('Unsaved map'); // State to hold the map name
-    const [dropdownVisible, setDropdownVisible] = useState(false); // State to hold the dropdown visibility
-    const [isFormModalOpen, setFormModalOpen] = useState(false);
+  const router = useRouter();
+  const [mapName, setMapName] = useState('Unsaved map'); // State to hold the map name
+  const [dropdownVisible, setDropdownVisible] = useState(false); // State to hold the dropdown visibility
+  const [isFormModalOpen, setFormModalOpen] = useState(false);
 
-    //Convert Markers to GeoJSON
-    const markersToGeoJsonFeatures = (markers: { latitude: number; longitude: number; type: string }[]) => {
-        console.log(markers);
-        return markers.map(marker => ({
-            type: 'Feature',
-            properties: {
-                name: marker.type // Assuming 'type' is the name you want to use for the marker
-            },
-            geometry: {
-                type: 'Point',
-                coordinates: [marker.longitude, marker.latitude] // GeoJSON uses [longitude, latitude]
-            }
-        }));
-    };
+  //Convert Markers to GeoJSON
+  const markersToGeoJsonFeatures = (markers: { latitude: number; longitude: number; type: string }[]) => {
+    console.log(markers);
+    return markers.map(marker => ({
+      type: 'Feature',
+      properties: {
+        name: marker.type // Assuming 'type' is the name you want to use for the marker
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [marker.longitude, marker.latitude] // GeoJSON uses [longitude, latitude]
+      }
+    }));
+  };
 
-    // Add a new function to handle the click event of the Feedback button
-    const handleFeedbackClick = () => {
-        setFormModalOpen(true);
-    };
+  // Add a new function to handle the click event of the Feedback button
+  const handleFeedbackClick = () => {
+    setFormModalOpen(true);
+  };
 
-    const handleExportClickWMarkers = () => {
-        if (props.geoJsonPath && props.markers) {
-            console.log('Markers:', props.markers);
-            // Convert the markers to GeoJSON features
-            const markerFeatures = markersToGeoJsonFeatures(props.markers);
-    
-            // Add the marker features to the GeoJSON data
-            const geoJsonDataWithMarkers = {
-                ...props.geoJsonPath,
-                features: [...props.geoJsonPath.features, ...markerFeatures]
-            };
-    
-            // Convert the GeoJSON object to a string
-            const geoJsonString = JSON.stringify(geoJsonDataWithMarkers, null, 2);
-    
-            // Create a Blob from the string
-            const blob = new Blob([geoJsonString], { type: 'application/geo+json' });
-    
-            // Create a URL for the Blob
-            const url = URL.createObjectURL(blob);
-    
-            // Create a temporary anchor element
-            const link = document.createElement('a');
-            link.href = url;
-            link.download = `${mapName}.geojson`; // Use the edited map name
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-    
-            // Release the URL for the Blob
-            URL.revokeObjectURL(url);
-        } else {
-            console.error('GeoJSON data or markers are not available.');
-        }
-    };
+  const handleExportClickWMarkers = () => {
+    if (props.geoJsonPath && props.markers) {
+      console.log('Markers:', props.markers);
+      // Convert the markers to GeoJSON features
+      const markerFeatures = markersToGeoJsonFeatures(props.markers);
 
-    // Handler for the export button click event
-    const handleExportClick = () => {
-        if (props.geoJsonPath) {
-            const geoJsonString = JSON.stringify(props.geoJsonPath, null, 2);
-            const blob = new Blob([geoJsonString], { type: 'application/geo+json' });
-            const url = URL.createObjectURL(blob);
-    
-            const link = document.createElement('a');
-            link.href = url;
-            link.download = `${mapName}.geojson`; // Corrected to use backticks
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-    
-            URL.revokeObjectURL(url);
-        }
-    };
-    
-    const toggleDropdown = () => {
-        setDropdownVisible(!dropdownVisible);
+      // Add the marker features to the GeoJSON data
+      const geoJsonDataWithMarkers = {
+        ...props.geoJsonPath,
+        features: [...props.geoJsonPath.features, ...markerFeatures]
+      };
+
+      // Convert the GeoJSON object to a string
+      const geoJsonString = JSON.stringify(geoJsonDataWithMarkers, null, 2);
+
+      // Create a Blob from the string
+      const blob = new Blob([geoJsonString], { type: 'application/geo+json' });
+
+      // Create a URL for the Blob
+      const url = URL.createObjectURL(blob);
+
+      // Create a temporary anchor element
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${mapName}.geojson`; // Use the edited map name
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      // Release the URL for the Blob
+      URL.revokeObjectURL(url);
+    } else {
+      console.error('GeoJSON data or markers are not available.');
     }
+  };
 
-    return (
-        <header className="flex items-center justify-between p-2 px-4 border-b dark:border-b-gray-600 dark:text-gray-300">
-            {props.viewAllOptions ? (
-                <>
-                    <div className="flex items-center space-x-4">
-                        <Button variant="ghost" onClick={() => props.onDiscardClick()}>Discard</Button>
-                        <input
-                            type="text"
-                            value={mapName}
-                            onChange={(e) => setMapName(e.target.value)}
-                            className="text-xl font-semibold bg-transparent border-none outline-none"
-                            placeholder="Unsaved map"
-                        />
-                    </div>
-                    <div className="flex items-center space-x-4">
-                        <div className="relative">
-                            <Button variant="blue" onClick={toggleDropdown}>Export map</Button>
-                            {dropdownVisible && (
-                                <div className="absolute top-full mt-2 w-full min-w-max rounded-md z-10 flex flex-col">
-                                    <Button variant="default" onClick={handleExportClick} className="mb-2">Export GeoJSON</Button>
-                                    <Button variant="default" onClick={handleExportClickWMarkers} className="mb-2">Export GeoJSON with markers</Button>
-                                </div>
-                            )}
-                        </div>
-                        <Button variant="green" onClick={handleFeedbackClick}>Feedback</Button>
-                        {/* <Button variant="secondary" disabled>Save map</Button> */}
-                        {isFormModalOpen && <FormModal onClose={() => setFormModalOpen(false)} />}
-                    </div>
-                </>
-            ) : (
-                <div className="flex items-center space-x-4">
-                    <Button variant="ghost" onClick={() => router.push("/")}>
-                        <div className="flex items-center space-x-2">
-                            <ChevronArrowIcon className="inline-flex h-5 w-5" left={1} />Back
-                        </div>
-                    </Button>
+  // Handler for the export button click event
+  const handleExportClick = () => {
+    if (props.geoJsonPath) {
+      const geoJsonString = JSON.stringify(props.geoJsonPath, null, 2);
+      const blob = new Blob([geoJsonString], { type: 'application/geo+json' });
+      const url = URL.createObjectURL(blob);
+
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${mapName}.geojson`; // Corrected to use backticks
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  const toggleDropdown = () => {
+    setDropdownVisible(!dropdownVisible);
+  }
+
+  return (
+    <header className="flex items-center justify-between p-2 px-4 border-b dark:border-b-gray-600 dark:text-gray-300">
+      {props.viewAllOptions ? (
+        <>
+          <div className="flex items-center space-x-4">
+            <Button variant="ghost" onClick={() => props.onDiscardClick()}>Discard</Button>
+            <input
+              type="text"
+              value={mapName}
+              onChange={(e) => setMapName(e.target.value)}
+              className="text-xl font-semibold bg-transparent border-none outline-none"
+              placeholder="Unsaved map"
+            />
+          </div>
+          <div className="flex items-center space-x-4">
+            <div className="relative">
+              <Button variant="blue" onClick={toggleDropdown}>Export map</Button>
+              {dropdownVisible && (
+                <div className="absolute top-full mt-2 w-full min-w-max rounded-md z-10 flex flex-col">
+                  <Button variant="default" onClick={handleExportClick} className="mb-2">Export GeoJSON</Button>
+                  <Button variant="default" onClick={handleExportClickWMarkers} className="mb-2">Export GeoJSON with markers</Button>
                 </div>
-            )}
-        </header>
-    );
+              )}
+            </div>
+            <Button variant="green" onClick={handleFeedbackClick}>Feedback</Button>
+            {/* <Button variant="secondary" disabled>Save map</Button> */}
+            {isFormModalOpen && <FormModal onClose={() => setFormModalOpen(false)} />}
+          </div>
+        </>
+      ) : (
+        <div className="flex items-center space-x-4">
+          <Button variant="ghost" onClick={() => router.push("/")}>
+            <div className="flex items-center space-x-2">
+              <ChevronArrowIcon className="inline-flex h-5 w-5" left={1} />Back
+            </div>
+          </Button>
+        </div>
+      )}
+    </header>
+  );
 }
 
 export { Toolbar }


### PR DESCRIPTION
# Improvements to the input display 

Input display is now its own component, shared between both Chat and Text/CSV.
The display has been improved with a small toolbar that displays both the number of returned locations, and the button for editing the initial input.

> ![image](https://github.com/TheAtlasRepository/Text2Map/assets/89195051/504dccbe-0dca-4ac1-84c1-751df5c86a55)

## Editing
The textarea for editing has also been revamped. When editing is enabled the textarea will be shiwn, along with options to `Cancel` or to `Save & resend`. If Textarea is empty, the option to save becomes disabled.
The height of the textarea is also responsive to the given input and will resize automatically as you write.

> ![image](https://github.com/TheAtlasRepository/Text2Map/assets/89195051/aa1a6e65-3c9d-41d1-b7cd-1eba9e5bb1ca)

## JsonTweeks
The returned answer text from GPT is now rotated to display history of oldest to newest from top to bottop, showing user request first at the top, followed by respons from assistant. JsonRenderer is now configured to add linebreaks and spacing throughout the text to break it up a little. There are now paragraph spacing, in addition to giving new line to numbered elements.

> ![image](https://github.com/TheAtlasRepository/Text2Map/assets/89195051/9febb0c3-f5cd-4f33-83dc-72d2fb7dbb4f)


## Other changes
- Slight tweeking and refactoring of logic in ApiUtil, askingView, startChatGPt and startDataSourceInput
  - Renamed some handlers and values
  - Removed a number of useStates and React Dispatches that became obsolete
- Added simple confirmation window when `Discard` in the toolbar is clicked, asking if the user is sure.
- Moved center coordinate value
- Many small tweeks and fixes
- Code cleanup